### PR TITLE
add bash source command

### DIFF
--- a/labs/lab3/README.md
+++ b/labs/lab3/README.md
@@ -196,6 +196,10 @@ Run the following command:
 
     source ~/.zshrc
 
+If you are still using Bash, run the following command:
+
+    source ~/.bashrc
+
 ## Grading ##
 
 In a terminal, with the TA present:


### PR DESCRIPTION
Many students skip part 3, and source ~/.zshrc instead of ~/.bashrc